### PR TITLE
Add TsLint and Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependencies
+/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.vscode
+tsconfig.json
+tslint.json

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ export interface PKPassJson {
     storeCard?: PassStructureDictionary
 
     // Visual Appearance Keys
-    // TODO: "color, as a string"
+    // TODO: 'color, as a string'
     barcode?: BarcodeDictionary
     barcodes?: Array<BarcodeDictionary>
     backgroundColor?: string
@@ -105,7 +105,8 @@ interface StandardFieldDictionary {
 
 /**
  * Information about how a date should be displayed in a field.
- * If any of these keys is present, the value of the field is treated as a date. Either specify both a date style and a time style, or neither.
+ * If any of these keys is present, the value of the field is treated as a date.
+ * Either specify both a date style and a time style, or neither.
  */
 interface DateStyle {
     dateStyle: PKDateStyle
@@ -116,21 +117,47 @@ interface DateStyle {
 
 /**
  * Information about how a number should be displayed in a field.
- * These keys are optional if the field’s value is a number; otherwise, they are not allowed. Only one of these keys is allowed per field.
+ * These keys are optional if the field’s value is a number; otherwise, they are not allowed.
+ * Only one of these keys is allowed per field.
  */
 interface NumberStyle {
     currencyCode: string
     numberStyle: PKNumberStyle
 }
 
-type PKBarcodeFormat = "PKBarcodeFormatQR" | "PKBarcodeFormatPDF417" | "PKBarcodeFormatAztec"
+type PKBarcodeFormat =
+    'PKBarcodeFormatQR' |
+    'PKBarcodeFormatPDF417' |
+    'PKBarcodeFormatAztec'
 
-type PKDataDetectorType = "PKDataDetectorTypePhoneNumber" | "PKDataDetectorTypeLink" | "PKDataDetectorTypeAddress" | "PKDataDetectorTypeCalendarEvent"
+type PKDataDetectorType =
+    'PKDataDetectorTypePhoneNumber' |
+    'PKDataDetectorTypeLink' |
+    'PKDataDetectorTypeAddress' |
+    'PKDataDetectorTypeCalendarEvent'
 
-type PKDateStyle = "PKDateStyleNone" | "PKDateStyleShort" | "PKDateStyleMedium" | "PKDateStyleLong" | "PKDateStyleFull"
+type PKDateStyle =
+    'PKDateStyleNone' |
+    'PKDateStyleShort' |
+    'PKDateStyleMedium' |
+    'PKDateStyleLong' |
+    'PKDateStyleFull'
 
-type PKNumberStyle = "PKNumberStyleDecimal" | "PKNumberStylePercent" | "PKNumberStyleScientific" | "PKNumberStyleSpellOut"
+type PKNumberStyle =
+    'PKNumberStyleDecimal' |
+    'PKNumberStylePercent' |
+    'PKNumberStyleScientific' |
+    'PKNumberStyleSpellOut'
 
-type PKTextAlignment = "PKTextAlignmentLeft" | "PKTextAlignmentCenter" | "PKTextAlignmentRight" | "PKTextAlignmentNatural"
+type PKTextAlignment =
+    'PKTextAlignmentLeft' |
+    'PKTextAlignmentCenter' |
+    'PKTextAlignmentRight' |
+    'PKTextAlignmentNatural'
 
-type PKTransitType = "PKTransitTypeAir" | "PKTransitTypeBoat" | "PKTransitTypeBus" | "PKTransitTypeGeneric" | "PKTransitTypeTrain" 
+type PKTransitType =
+    'PKTransitTypeAir' |
+    'PKTransitTypeBoat' |
+    'PKTransitTypeBus' |
+    'PKTransitTypeGeneric' |
+    'PKTransitTypeTrain' 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "TypeScript types file for PassKit pass.json structure",
   "main": "index.ts",
+  "scripts": {
+    "lint": "tslint ./index.ts"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/responsifi/passkit-json-ts.git"
@@ -21,5 +24,11 @@
   "bugs": {
     "url": "https://github.com/responsifi/passkit-json-ts/issues"
   },
-  "homepage": "https://github.com/responsifi/passkit-json-ts#readme"
+  "homepage": "https://github.com/responsifi/passkit-json-ts#readme",
+  "devDependencies": {
+    "tslint": "^5.9.1",
+    "tslint-config-prettier": "^1.10.0",
+    "tslint-config-standard": "^7.0.0",
+    "typescript": "^2.7.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passkit-json-ts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript types file for PassKit pass.json structure",
   "main": "index.ts",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": [
+    "index.ts"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "tslint-config-standard",
+    "tslint-config-prettier"
+  ]
+}


### PR DESCRIPTION
Add `tslint` linter using `tslint-config-prettier` and `tslint-config-standard` preset configs. Fix the lint errors generated from `index.ts` and add an `.npmignore` file.